### PR TITLE
Fixed the URL of the card.list_cards() endpoint.

### DIFF
--- a/src/routes/wallet/deposit/card/index.ts
+++ b/src/routes/wallet/deposit/card/index.ts
@@ -13,7 +13,7 @@ export class WalletDepositCardRoutes {
   }
 
   public async list_cards(): Promise<unknown> {
-    return this.api.post<unknown>(`${this.baseUri}/add_card`, {});
+    return this.api.post<unknown>(`${this.baseUri}/list_cards`, {});
   }
 
   public async deposit_card(payload: IDepositCardPayload): Promise<unknown> {


### PR DESCRIPTION
Before this the `card.list_cards()` would point to the same endpoint as `card.add_card()` and would not work... This should fix this error!